### PR TITLE
fix: fixed implementation of dmabuf so wlr portal doesnt crash on start

### DIFF
--- a/include/wlr.h
+++ b/include/wlr.h
@@ -48,6 +48,7 @@ extern "C" {
 #include <wlr/util/region.h>
 
 // Unstable
+#include <wlr/types/wlr_drm.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_ext_foreign_toplevel_list_v1.h>

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -136,7 +136,7 @@ Server::Server(struct Config *config) {
         ::exit(1);
     }
 
-    wlr_renderer_init_wl_display(renderer, wl_display);
+    wlr_renderer_init_wl_shm(renderer, wl_display);
 
     // render allocator
     allocator = wlr_allocator_autocreate(backend, renderer);
@@ -428,6 +428,7 @@ Server::Server(struct Config *config) {
 
     // linux dmabuf
     if (wlr_renderer_get_texture_formats(renderer, WLR_BUFFER_CAP_DMABUF)) {
+        wlr_drm_create(wl_display, renderer);
         wlr_linux_dmabuf =
             wlr_linux_dmabuf_v1_create_with_renderer(wl_display, 4, renderer);
         wlr_scene_set_linux_dmabuf_v1(scene, wlr_linux_dmabuf);


### PR DESCRIPTION
transitions from tinywl's unified initialization of both wl_shm and linux-dmabuf to a split one that the linux-dmabuf protocol requires to work correctly