### PR TITLE
fix(build): specify minimum required meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project(
     'buildtype=release',
     'cpp_std=c++17',
   ],
+  meson_version: '>= 1.1',
 )
 
 # optional xwayland support


### PR DESCRIPTION
Fixes meson warning about using meson.options file that was added in meson version 1.1

MOM LOOK I'M AN AWM CONTRIBUTOR